### PR TITLE
Update event keys for Google Analytics

### DIFF
--- a/src/app/services/google-analytics.service.ts
+++ b/src/app/services/google-analytics.service.ts
@@ -12,15 +12,13 @@ export class GoogleAnalyticsService {
   public eventEmitter(
     eventName: string,
     eventCategory: string,
-    eventAction: string,
     eventLabel: string = null,
     eventValue: number = null
   ){
     gtag('event', eventName, {
-      eventCategory: eventCategory,
-      eventLabel: eventLabel,
-      eventAction: eventAction,
-      eventValue: eventValue
+      event_category: eventCategory,
+      event_label: eventLabel,
+      value: eventValue
     })
   }
 }

--- a/src/app/shop/shop.component.ts
+++ b/src/app/shop/shop.component.ts
@@ -14,7 +14,7 @@ export class ShopComponent implements OnInit {
   }
 
   SendAddToCartEvent(){
-    this.googleAnalyticsService.eventEmitter("add_to_cart", "shop", "cart", "click", 1);
+    this.googleAnalyticsService.eventEmitter("add_to_cart", "shop", "cart", 1);
   }
 
 }


### PR DESCRIPTION
The event keys need to be like in the reference in order to be visible in Google Analytics Dashboard.

https://developers.google.com/analytics/devguides/collection/gtagjs/events